### PR TITLE
Bugfix/edit spending totals

### DIFF
--- a/static/js/spending/model/spendingReport.js
+++ b/static/js/spending/model/spendingReport.js
@@ -17,9 +17,6 @@ export default class SpendingReport {
 	/** @type {Planning} */
 	#planning = undefined;
 
-	/** @type {number} */
-	#total = 0;
-
 	static MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 	/**
@@ -44,7 +41,6 @@ export default class SpendingReport {
 		if (this.invalidBoughtDate(spending)) return;
 
 		this.#spendings.push(spending);
-		this.#total += spending.price;
 		this.#spentGoals.add(spending.category);
 	}
 
@@ -80,7 +76,7 @@ export default class SpendingReport {
 	 * @returns {number}
 	 */
 	total() {
-		return this.#total.toFixed(2);
+		return this.#spendings.reduce((acc, current) => acc + current.price, 0);
 	}
 
 	/**
@@ -102,7 +98,7 @@ export default class SpendingReport {
 	 * @returns {Spending}
 	 */
 	totalAsSpending() {
-		return new Spending(`total-${this.#month}`, '-', '-', '-', 'Total', this.#total);
+		return new Spending(`total-${this.#month}`, '-', '-', '-', 'Total', this.total());
 	}
 
 	/**

--- a/static/js/spending/model/spendingReport.js
+++ b/static/js/spending/model/spendingReport.js
@@ -141,15 +141,9 @@ export default class SpendingReport {
 		}
 
 		const changedSpendings = this.#spendings.filter((spending) => spending.edited);
-		if (changedSpendings.length > 0) {
-			changedSpendings.forEach((changedSpending) => {
-				for (let index = 0; index < this.changedSpendings.length; index += 1) {
-					const searchedSpending = this.#spendings[index];
-					if (changedSpending.id === searchedSpending.id) {
-						delete searchedSpending.edited;
-					}
-				}
-			});
+		for (let index = 0; index < changedSpendings.length; index += 1) {
+			const searchedSpending = changedSpendings[index];
+			delete searchedSpending.edited;
 		}
 
 		return changedSpendings.length > 0 || deletedSpendings.length > 0;

--- a/static/js/spending/view/spendingScreen.js
+++ b/static/js/spending/view/spendingScreen.js
@@ -376,10 +376,10 @@ export default class SpendingScreen {
 
 		switch (cellIndex) {
 		case 0:
-			spending.description = cell.textContent;
+			spending.spentOn.setDate(+cell.textContent);
 			break;
 		case 1:
-			spending.spentOn = cell.valueAsDate;
+			spending.description = cell.textContent;
 			break;
 		case 2:
 			spending.category = cell.textContent;
@@ -428,6 +428,9 @@ export default class SpendingScreen {
 				const reportChanged = spendingReport.applyChanges();
 				// Do not call the handler if the report did not change
 				if (this.onSaveReportCallback && reportChanged) {
+					slice.toHtml().getElementsByTagName('table')[0].tFoot.replaceChildren(
+						this.buildReadOnlyRow(spendingReport.totalAsSpending()).toHtml(),
+					);
 					this.onSaveReportCallback(spendingReport);
 				}
 			}


### PR DESCRIPTION
In this pull request:

- The #total attribute was removed and it was replaced with a generic reducing function. This was done because the old value was not updated when needed and the effort for updating it was large (the reducing function only performs some small additions).
- The logic for applying edits in spending reports was greatly simplified. The new version deletes the "edit" flag directly, whereas the old version looked for a matching spending in the main list from the report. I was thinking that filtering creates an additional object, but this was not the case.
- After the spending gets updated, the GUI needs to change. The total row for each table should be replaced. Also, there was a column mismatch between the date and description column that deleted old data from the persistence layer. That one was also fixed
