### PR TITLE
Feature/edit spending modal

### DIFF
--- a/static/js/common/gui/dom.js
+++ b/static/js/common/gui/dom.js
@@ -173,7 +173,22 @@ export default class Dom {
 		return this;
 	}
 
-	toHtml() {
+	toHtml(target) {
+		if (target) {
+			Object.assign(target, this.elmt);
+		}
+		return this.elmt;
+	}
+
+	/**
+	 * Shallow copy the content of current DOM instance to provided DOM instance
+	 * @param {Dom} target\ The instance where to copy the content to
+	 * @returns current DOM instance
+	 */
+	cloneTo(target) {
+		if (target) {
+			Object.assign(target, this);
+		}
 		return this.elmt;
 	}
 

--- a/static/js/common/gui/dom.js
+++ b/static/js/common/gui/dom.js
@@ -158,6 +158,11 @@ export default class Dom {
 		return this;
 	}
 
+	onFocus(listener) {
+		this.elmt.addEventListener('focus', listener, false);
+		return this;
+	}
+
 	text(text) {
 		this.elmt.textContent = text;
 		return this;

--- a/static/js/common/gui/modal.js
+++ b/static/js/common/gui/modal.js
@@ -4,6 +4,9 @@ export default class Modal {
 	/** @type {boolean} */
 	#isOpen = false;
 
+	/** @type {Dom} */
+	#headerDom = undefined;
+
 	constructor(id) {
 		this.id = id;
 		const onClose = this.close.bind(this);
@@ -31,10 +34,13 @@ export default class Modal {
 	}
 
 	header(...domElements) {
-		this.content.append(
-			new Dom('div').cls('modal-header').append(
-				...domElements,
-			),
+		if (!this.#headerDom) {
+			this.#headerDom = new Dom('div').cls('modal-header');
+			this.content.append(this.#headerDom);
+		}
+		this.#headerDom.clear();
+		this.#headerDom.append(
+			...domElements,
 		);
 		return this;
 	}

--- a/static/js/planning/view/planningScreen.js
+++ b/static/js/planning/view/planningScreen.js
@@ -103,7 +103,7 @@ export default class PlanningScreen {
 		const onClickAddCategory = this.onClickedAddCategory.bind(this, statement);
 		const slice = new Dom('div').id(`statement-${statement.id}`).cls('slice').append(
 			new Dom('h1').text(statement.name).editable().onKeyUp(onKeyUp).attr('contenteditable', this.#editMode),
-			new Dom('h2').id('planning-statement-type').text(`${statement.type} `).onClick(onClickStatementType).hideable(this.#editMode)
+			new Dom('h2').text(`${statement.type} `).onClick(onClickStatementType).hideable(this.#editMode)
 				.append(
 					new Dom('span').cls('white-50').text('▼'),
 				),

--- a/static/js/spending/view/spendingCategoryModal.js
+++ b/static/js/spending/view/spendingCategoryModal.js
@@ -1,0 +1,51 @@
+import Dom from '../../common/gui/dom.js';
+import Modal from '../../common/gui/modal.js';
+
+export default class SpendingCategoryModal {
+	#modalDom = undefined;
+
+	constructor(forCategories, onClickCategoryCallback) {
+		if (!forCategories || forCategories.length === 0) {
+			this.#modalDom = new Modal('categories')
+				.header(
+					new Dom('h2').text('Cannot Insert Spending'),
+				).body(
+					new Dom('div').cls('accordion').text('Plan your goals first!'),
+				).addCancelFooter();
+			return;
+		}
+
+		const onClickCategoryHeader = SpendingCategoryModal.#onClickCategoryHeader;
+
+		this.#modalDom = new Modal('categories')
+			.header(
+				new Dom('h2').text('Insert Spending'),
+			).body(
+				new Dom('div').cls('accordion').append(
+					...forCategories.map((category) => new Dom('div').cls('accordion-item').onTransitionEnd(onClickCategoryHeader).append(
+						new Dom('input').id(category.id).cls('accordion-state').attr('type', 'checkbox'),
+						new Dom('label').cls('accordion-header').attr('for', category.id).append(
+							new Dom('span').text(category.name),
+						),
+						new Dom('div').cls('accordion-content').append(
+							...category.goals.map((goal) => new Dom('div').cls('accordion-secondary').text(goal.name).onClick(onClickCategoryCallback)),
+						),
+					)),
+				),
+			).scrollable()
+			.addCancelFooter();
+	}
+
+	open() {
+		this.#modalDom.open();
+	}
+
+	close() {
+		this.#modalDom.close();
+	}
+
+	static #onClickCategoryHeader(event) {
+		const header = event.currentTarget;
+		header.scrollIntoView(true);
+	}
+}

--- a/static/js/spending/view/spendingSubmitModal.js
+++ b/static/js/spending/view/spendingSubmitModal.js
@@ -1,0 +1,134 @@
+import Dom from '../../common/gui/dom.js';
+import Modal from '../../common/gui/modal.js';
+import { Category } from '../../planning/model/planningModel.js';
+import Spending from '../model/spending.js';
+import SpendingCategoryModal from './spendingCategoryModal.js';
+
+export default class SpendingSubmitModal {
+	#modalDom = undefined;
+
+	#categoryModal = undefined;
+
+	#onClickSaveHandler = undefined;
+
+	#spending = undefined;
+
+	constructor(forCategories, onClickSaveHandler) {
+		this.#onClickSaveHandler = onClickSaveHandler;
+		const onClickCategoryInput = this.#onClickCategoryInput.bind(this);
+
+		this.#modalDom = new Modal('add-spending').header(
+			new Dom('h2').text('Insert Spending'),
+		).body(
+			new Dom('form').append(
+				new Dom('div').cls('input-field').append(
+					new Dom('input').id('date-input-field').type('date').attr('required', '').attr('value', new Date().toISOString().substring(0, 10)),
+					new Dom('label').text('Date: '),
+				),
+				new Dom('div').cls('input-field').append(
+					new Dom('input').id('category-input-field').type('text').attr('required', '').onClick(onClickCategoryInput).onFocus(onClickCategoryInput),
+					new Dom('label').text('Category: '),
+				),
+				new Dom('div').cls('input-field').append(
+					new Dom('input').id('price-input-field').type('number').attr('required', '').attr('step', '0.01'),
+					new Dom('label').text('Price: '),
+				),
+				new Dom('div').cls('input-field').append(
+					new Dom('input').id('description-input-field').type('text').attr('required', ''),
+					new Dom('label').text('Description: '),
+				),
+				new Dom('input').type('submit').hide().onClick(this.#onClickSave.bind(this)),
+			),
+		).footer(
+			new Dom('h3').text('Cancel').onClick(this.close.bind(this)),
+			new Dom('h3').text('Save').onClick(this.#onClickSave.bind(this)),
+		);
+
+		this.#buildCategoryModal(forCategories);
+	}
+
+	/**
+	 * @param {Array<Category>} forCategories
+	 * @returns {Dom}
+	 */
+	#buildCategoryModal(forCategories) {
+		const onClickCategory = this.#onClickCategory.bind(this);
+		this.#categoryModal = new SpendingCategoryModal(forCategories, onClickCategory);
+		return this.#categoryModal;
+	}
+
+	open() {
+		this.#modalDom.open();
+	}
+
+	close() {
+		this.#modalDom.close();
+	}
+
+	editMode(spending) {
+		this.#modalDom.header(new Dom('h2').text('Edit Spending'));
+		this.#spending = spending;
+		this.#spending.edited = true;
+	}
+
+	insertMode() {
+		this.#modalDom.header(new Dom('h2').text('Insert Spending'));
+		this.#spending = new Spending(new Date().getTime());
+	}
+
+	#onClickSave(event) {
+		event.preventDefault();
+		this.#spending.spentOn = document.getElementById('date-input-field').valueAsDate;
+		this.#spending.description = document.getElementById('description-input-field').value;
+		this.#spending.price = +document.getElementById('price-input-field').value;
+		this.#spending.category = document.getElementById('category-input-field').value;
+
+		if (!this.#spending.price) {
+			document.getElementById('price-input-field').focus();
+			return;
+		}
+
+		this.close();
+		if (this.#onClickSaveHandler) {
+			this.#onClickSaveHandler(this.#spending);
+		}
+	}
+
+	#onClickCategory(event) {
+		// TODO move setters in modal
+		this.#categoryModal.close();
+		this.open();
+		const categoryInput = document.getElementById('category-input-field');
+		const descriptionInput = document.getElementById('description-input-field');
+		const priceInput = document.getElementById('price-input-field');
+		categoryInput.value = event.target.textContent;
+		descriptionInput.value = '';
+		priceInput.value = '';
+		this.#focusInputField('price-input-field');
+	}
+
+	#onClickCategoryInput() {
+		if (this.isOpen()) {
+			this.close();
+		}
+		this.#categoryModal.open();
+	}
+
+	#focusInputField(withId) {
+		/* Focus cannot be applied to invisible elements.
+		 * We need to wait for elemnt to be focusable.
+		 * We also cannot use display: none -> display: visible because 'display' cannot be animated
+		 */
+		requestAnimationFrame(() => {
+			const priceInputField = document.getElementById(withId);
+			priceInputField.focus();
+			if (document.activeElement !== priceInputField) {
+				requestAnimationFrame(this.#focusInputField.bind(this, withId));
+			}
+		});
+	}
+
+	isOpen() {
+		return this.#modalDom.isOpen();
+	}
+}

--- a/static/js/spending/view/spendingSubmitModal.js
+++ b/static/js/spending/view/spendingSubmitModal.js
@@ -5,43 +5,60 @@ import Spending from '../model/spending.js';
 import SpendingCategoryModal from './spendingCategoryModal.js';
 
 export default class SpendingSubmitModal {
-	#modalDom = undefined;
+	/** @type {Modal} */
+	#submitSpendingDom = undefined;
 
+	/** @type {SpendingCategoryModal} */
 	#categoryModal = undefined;
 
-	#onClickSaveHandler = undefined;
+	#onInsertHandler = undefined;
+
+	#onEditHandler = undefined;
 
 	#spending = undefined;
 
-	constructor(forCategories, onClickSaveHandler) {
-		this.#onClickSaveHandler = onClickSaveHandler;
-		const onClickCategoryInput = this.#onClickCategoryInput.bind(this);
+	#editMode = false;
 
-		this.#modalDom = new Modal('add-spending').header(
+	/** @type {Dom} */
+	#dateInput = new Dom();
+
+	/** @type {Dom} */
+	#descriptionInput = new Dom();
+
+	/** @type {Dom} */
+	#categoryInput = new Dom();
+
+	/** @type {Dom} */
+	#priceInput = new Dom();
+
+	constructor(forCategories) {
+		const onClickCategoryInput = this.#onClickedCategoryInput.bind(this);
+
+		this.#submitSpendingDom = new Modal('add-spending').header(
 			new Dom('h2').text('Insert Spending'),
 		).body(
 			new Dom('form').append(
 				new Dom('div').cls('input-field').append(
-					new Dom('input').id('date-input-field').type('date').attr('required', '').attr('value', new Date().toISOString().substring(0, 10)),
+					new Dom('input').type('date').attr('required', '').attr('value', new Date().toISOString().substring(0, 10)).cloneTo(this.#dateInput),
 					new Dom('label').text('Date: '),
 				),
 				new Dom('div').cls('input-field').append(
-					new Dom('input').id('category-input-field').type('text').attr('required', '').onClick(onClickCategoryInput).onFocus(onClickCategoryInput),
+					new Dom('input').type('text').attr('required', '').onClick(onClickCategoryInput).onFocus(onClickCategoryInput).cloneTo(this.#categoryInput),
 					new Dom('label').text('Category: '),
 				),
 				new Dom('div').cls('input-field').append(
-					new Dom('input').id('price-input-field').type('number').attr('required', '').attr('step', '0.01'),
+					new Dom('input').type('number').attr('required', '').attr('step', '0.01').cloneTo(this.#priceInput),
 					new Dom('label').text('Price: '),
 				),
 				new Dom('div').cls('input-field').append(
-					new Dom('input').id('description-input-field').type('text').attr('required', ''),
+					new Dom('input').type('text').attr('required', '').cloneTo(this.#descriptionInput),
 					new Dom('label').text('Description: '),
 				),
-				new Dom('input').type('submit').hide().onClick(this.#onClickSave.bind(this)),
+				new Dom('input').type('submit').hide().onClick(this.#onClickedSave.bind(this)),
 			),
 		).footer(
 			new Dom('h3').text('Cancel').onClick(this.close.bind(this)),
-			new Dom('h3').text('Save').onClick(this.#onClickSave.bind(this)),
+			new Dom('h3').text('Save').onClick(this.#onClickedSave.bind(this)),
 		);
 
 		this.#buildCategoryModal(forCategories);
@@ -52,83 +69,99 @@ export default class SpendingSubmitModal {
 	 * @returns {Dom}
 	 */
 	#buildCategoryModal(forCategories) {
-		const onClickCategory = this.#onClickCategory.bind(this);
+		const onClickCategory = this.#onClickedCategory.bind(this);
 		this.#categoryModal = new SpendingCategoryModal(forCategories, onClickCategory);
 		return this.#categoryModal;
 	}
 
+	isOpen() {
+		return this.#submitSpendingDom.isOpen();
+	}
+
 	open() {
-		this.#modalDom.open();
+		this.#submitSpendingDom.open();
 	}
 
 	close() {
-		this.#modalDom.close();
+		this.#submitSpendingDom.close();
 	}
 
 	editMode(spending) {
-		this.#modalDom.header(new Dom('h2').text('Edit Spending'));
+		this.#editMode = true;
+		this.#submitSpendingDom.header(new Dom('h2').text('Edit Spending'));
 		this.#spending = spending;
 		this.#spending.edited = true;
+
+		this.#dateInput.toHtml().valueAsDate = spending.spentOn;
+		this.#descriptionInput.toHtml().value = spending.description;
+		this.#categoryInput.toHtml().value = spending.category;
+		this.#priceInput.toHtml().value = spending.price;
 	}
 
 	insertMode() {
-		this.#modalDom.header(new Dom('h2').text('Insert Spending'));
+		this.#editMode = false;
+
+		this.#submitSpendingDom.header(new Dom('h2').text('Insert Spending'));
 		this.#spending = new Spending(new Date().getTime());
+
+		this.#descriptionInput.toHtml().value = '';
+		this.#categoryInput.toHtml().value = '';
+		this.#priceInput.toHtml().value = '';
 	}
 
-	#onClickSave(event) {
+	onEditSpending(handler) {
+		this.#onEditHandler = handler;
+	}
+
+	onInsertSpending(handler) {
+		this.#onInsertHandler = handler;
+	}
+
+	#onClickedSave(event) {
 		event.preventDefault();
-		this.#spending.spentOn = document.getElementById('date-input-field').valueAsDate;
-		this.#spending.description = document.getElementById('description-input-field').value;
-		this.#spending.price = +document.getElementById('price-input-field').value;
-		this.#spending.category = document.getElementById('category-input-field').value;
+		this.#spending.spentOn = this.#dateInput.toHtml().valueAsDate;
+		this.#spending.description = this.#descriptionInput.toHtml().value;
+		this.#spending.price = +(this.#priceInput.toHtml().value);
+		this.#spending.category = this.#categoryInput.toHtml().value;
 
 		if (!this.#spending.price) {
-			document.getElementById('price-input-field').focus();
+			this.#priceInput.toHtml().focus();
 			return;
 		}
 
 		this.close();
-		if (this.#onClickSaveHandler) {
-			this.#onClickSaveHandler(this.#spending);
+
+		if (this.#editMode && this.#onEditHandler) {
+			this.#onEditHandler(this.#spending);
+		} else if (this.#onInsertHandler) {
+			this.#onInsertHandler(this.#spending);
 		}
 	}
 
-	#onClickCategory(event) {
-		// TODO move setters in modal
+	#onClickedCategory(event) {
 		this.#categoryModal.close();
 		this.open();
-		const categoryInput = document.getElementById('category-input-field');
-		const descriptionInput = document.getElementById('description-input-field');
-		const priceInput = document.getElementById('price-input-field');
-		categoryInput.value = event.target.textContent;
-		descriptionInput.value = '';
-		priceInput.value = '';
-		this.#focusInputField('price-input-field');
+		this.#categoryInput.toHtml().value = event.target.textContent;
+		this.#focusInputField(this.#priceInput.toHtml());
 	}
 
-	#onClickCategoryInput() {
+	#onClickedCategoryInput() {
 		if (this.isOpen()) {
 			this.close();
 		}
 		this.#categoryModal.open();
 	}
 
-	#focusInputField(withId) {
+	#focusInputField(htmlElement) {
 		/* Focus cannot be applied to invisible elements.
 		 * We need to wait for elemnt to be focusable.
 		 * We also cannot use display: none -> display: visible because 'display' cannot be animated
 		 */
 		requestAnimationFrame(() => {
-			const priceInputField = document.getElementById(withId);
-			priceInputField.focus();
-			if (document.activeElement !== priceInputField) {
-				requestAnimationFrame(this.#focusInputField.bind(this, withId));
+			htmlElement.focus();
+			if (document.activeElement !== htmlElement) {
+				requestAnimationFrame(this.#focusInputField.bind(this, htmlElement));
 			}
 		});
-	}
-
-	isOpen() {
-		return this.#modalDom.isOpen();
 	}
 }


### PR DESCRIPTION
In this pull request:

- The IDs of the planning statement type were removed as they were duplicated. The slices can be identified by statement IDs or stored in attributes.
- The Category modal and the modal for Inserting a new spending were refactored from the screen file. This provides better data isolation and reduced code size for main Spending screen.
- The Submit Modal has enhanched editing capabilities
- The category modal is now also opened when the user tabs into the category input field (besides just clicking)