### PR TITLE
Bugfix/empty planning statements

### DIFF
--- a/static/js/common/gui/modal.js
+++ b/static/js/common/gui/modal.js
@@ -51,7 +51,7 @@ export default class Modal {
 			this.content.append(this.bodyDom);
 		}
 
-		this.bodyDom.append(
+		this.bodyDom.clear().append(
 			...domElements,
 		);
 

--- a/static/js/planning/view/planningNavbar.js
+++ b/static/js/planning/view/planningNavbar.js
@@ -108,14 +108,16 @@ export default class PlanningNavbar {
 	init() {
 		this.gfx = new GraphicEffects();
 		this.gfx.onSliceChange(this.onChangedStatementIndex.bind(this));
-		this.refresh();
+		this.refresh(this.#planning);
 	}
 
-	refresh() {
+	refresh(planning) {
+		this.#planning = planning;
 		if (this.gfx) {
 			const container = document.getElementById(this.#planning.year);
 			if (container) this.gfx.init(container);
 		}
+		this.refreshStatementDropup();
 	}
 
 	buildNavbarHeader() {
@@ -353,6 +355,18 @@ export default class PlanningNavbar {
 		this.#statementsInDropup.set(statement.name, statementDropupItem);
 		this.#statementsDropup.body(statementDropupItem);
 		this.updateStatementDropupText();
+	}
+
+	refreshStatementDropup() {
+		this.#statementsDropup.body(
+			...this.#planning.statements.map(this.#statementToDom.bind(this)),
+		);
+	}
+
+	#statementToDom(statement) {
+		const onStatementChanged = this.onChangedStatement.bind(this, statement);
+		const statementDropupItem = new Dom('div').cls('accordion-secondary').onClick(onStatementChanged).text(statement.name);
+		return statementDropupItem;
 	}
 
 	selectStatement(statementName) {

--- a/static/js/planning/view/planningNavbar.js
+++ b/static/js/planning/view/planningNavbar.js
@@ -452,7 +452,7 @@ export default class PlanningNavbar {
 					new Dom('label').text('Statement name: '),
 				),
 				new Dom('div').cls('input-field').onClick().append(
-					new Dom('input').id('statement-type-input').onClick(onClickStatementType).type('text').attr('required', ''),
+					new Dom('input').id('statement-type-input').onFocus(onClickStatementType).onClick(onClickStatementType).type('text').attr('required', ''),
 					new Dom('label').text('Type: '),
 				),
 				new Dom('input').type('submit').hide().onClick(onClickSave),

--- a/static/js/planning/view/planningNavbar.js
+++ b/static/js/planning/view/planningNavbar.js
@@ -67,8 +67,11 @@ export default class PlanningNavbar {
 		this.#planning = planning;
 		this.#selectedYear = planning.year;
 		this.#selectedMonth = planning.month;
+
 		if (planning.statements.length > 0) {
 			this.#selectedStatement = planning.statements[0];
+		} else {
+			this.#selectedStatement = new Statement(new Date().getTime(), 'No planning statements', Statement.EXPENSE, []);
 		}
 
 		this.buildYearModal();
@@ -117,7 +120,12 @@ export default class PlanningNavbar {
 			const container = document.getElementById(this.#planning.year);
 			if (container) this.gfx.init(container);
 		}
-		this.refreshStatementDropup();
+		if (planning.statements.length > 0) {
+			this.#selectedStatement = planning.statements[0];
+		} else {
+			this.#selectedStatement = new Statement(new Date().getTime(), 'No planning statements', Statement.EXPENSE, []);
+		}
+		this.#refreshStatementDropup();
 	}
 
 	buildNavbarHeader() {
@@ -177,11 +185,13 @@ export default class PlanningNavbar {
 	}
 
 	onClickedDeleteStatement() {
+		if (this.#planning.statements.length <= 1) {
+			Alert.show('Delete Planning', 'You cannot delete the last statement of a planning');
+			return;
+		}
+
 		this.#onClickedDeleteStatement?.(this.gfx.selectedIndex());
 		this.#selectedStatement = this.#planning.statements[0];
-		if (this.#selectedStatement) {
-			this.updateStatementDropupText();
-		}
 	}
 
 	// #endregion
@@ -357,7 +367,12 @@ export default class PlanningNavbar {
 		this.updateStatementDropupText();
 	}
 
-	refreshStatementDropup() {
+	#refreshStatementDropup() {
+		if (this.#planning.statements.length === 0) {
+			document.getElementById('planning-stmt-text').textContent = 'No planning statements';
+			return;
+		}
+
 		this.#statementsDropup.body(
 			...this.#planning.statements.map(this.#statementToDom.bind(this)),
 		);

--- a/static/js/planning/view/planningScreen.js
+++ b/static/js/planning/view/planningScreen.js
@@ -79,15 +79,10 @@ export default class PlanningScreen {
 	buildContainer(planning) {
 		const container = new Dom('div').id(planning.year).cls('container');
 		const section =	new Dom('div').cls('section');
-		const { statements } = planning;
-
-		for (let i = 0; i < statements.length; i += 1) {
-			const statement = statements[i];
-			const htmlStatement = this.buildStatement(statement).userData(statement);
-
-			section.append(htmlStatement);
-			this.navbar.appendStatement(statement);
-		}
+		planning.statements
+			.map(this.buildStatement.bind(this))
+			.reduce((dom, statement) => dom.append(statement), section);
+		this.navbar.refreshStatementDropup(planning);
 
 		container.append(section);
 		return container;
@@ -104,7 +99,7 @@ export default class PlanningScreen {
 		const onKeyUp = this.onKeyUpStatementName.bind(this);
 		const onClickStatementType = this.onClickedStatementType.bind(this);
 		const onClickAddCategory = this.onClickedAddCategory.bind(this, statement);
-		const slice = new Dom('div').id(`statement-${statement.id}`).cls('slice').append(
+		const slice = new Dom('div').id(`statement-${statement.id}`).cls('slice').userData(statement).append(
 			new Dom('h1').text(statement.name).editable().onKeyUp(onKeyUp).attr('contenteditable', this.#editMode),
 			new Dom('h2').text(`${statement.type} `).onClick(onClickStatementType).hideable(this.#editMode)
 				.append(
@@ -182,7 +177,7 @@ export default class PlanningScreen {
 		this.#defaultPlanning = planning;
 		const container = this.buildContainer(planning).toHtml();
 		this.containerHtml.parentElement.replaceChild(container, this.containerHtml);
-		this.navbar.refresh();
+		this.navbar.refresh(planning);
 		this.containerHtml = container;
 	}
 

--- a/static/js/planning/view/planningScreen.js
+++ b/static/js/planning/view/planningScreen.js
@@ -31,6 +31,9 @@ export default class PlanningScreen {
 			throw Error('No planning provided to draw on the screen');
 		}
 		this.#defaultPlanning = planning;
+		if (!this.#defaultPlanning.statements || this.#defaultPlanning.statements.length === 0) {
+			this.#defaultPlanning.statements = [new Statement(Date.now(), 'No planning statements', Statement.EXPENSE, [])];
+		}
 	}
 
 	/**

--- a/static/js/spending/controller/spendingController.js
+++ b/static/js/spending/controller/spendingController.js
@@ -52,7 +52,6 @@ export default class SpendingController {
 		}
 
 		const cachedPlannings = await this.#planningPersistence.readAllFromCache();
-		const updatedReports = [];
 		for (let month = 0; month < this.#cachedReports.length; month += 1) {
 			const report = this.#cachedReports[month];
 			if (report) {
@@ -60,7 +59,6 @@ export default class SpendingController {
 				report.updatePlanning(planning);
 			}
 		}
-		await Promise.all(updatedReports);
 
 		/** @type {SpendingScreen} */
 		this.#screen = new SpendingScreen(this.#defaultYear, this.#defaultMonth, this.#cachedReports);


### PR DESCRIPTION
In this pull request:

- Fix update of  planning screen for displaying empty planning
- Disallow deletion of last statement in a planning to avoid saving empty plannings.
- Add focus handling for statement type modal
- Generic refactorings